### PR TITLE
Fix - Sesión 5 - Typo en ejemplo 3

### DIFF
--- a/Sesion-05/Ejemplo-03/Readme.md
+++ b/Sesion-05/Ejemplo-03/Readme.md
@@ -16,7 +16,7 @@
 
 Cuando revisamos __SQL__ usamos agrupamientos que aplicaban una función a una columna reduciéndola a un valor que podía ser una suma, un conteo o calcular un promedio, por ejemplo. 
 
-En __MongoDB__ podemos realizar lo mismo mediante el uso de agregaciones. Las agregaciones, permiten realizar distintos filtros usando *capas*. Una capa es el resultado de la aplicación de algún filtro, proyección, agrupamiento, ordienamiento, etc. Cada capa puede usarse en una nueva capa. La primera capa siempre será la colección completa.
+En __MongoDB__ podemos realizar lo mismo mediante el uso de agregaciones. Las agregaciones, permiten realizar distintos filtros usando *capas*. Una capa es el resultado de la aplicación de algún filtro, proyección, agrupamiento, ordenamiento, etc. Cada capa puede usarse en una nueva capa. La primera capa siempre será la colección completa.
 
 Al conjunto de capas generadas en una agregación se le conoce como *pipeline*.
 


### PR DESCRIPTION
Encontré un pequeño typo, decía "ordienamiento" en vez de "ordenamiento".