### PR TITLE
Fix typo en ejemplo 4 y nombre de tabla en reto 3

### DIFF
--- a/Sesion-01/Ejemplo-04/Readme.md
+++ b/Sesion-01/Ejemplo-04/Readme.md
@@ -16,7 +16,7 @@
 
 ### 3. Desarrollo :rocket:
 
-1. Adicional a la restricción `WHERE`, es posible añadir otras restriccioens, por ejemplo, la restricción `ORDER BY` que permite ordenar los resultados de una consulta de manera ascendente (`ASC`) o descendente (`DESC`) a partir de un campo. Por ejemplo, la siguiente consulta muestra los resultados ordenados de mayor a menor a partir del campo `salario`.
+1. Adicional a la restricción `WHERE`, es posible añadir otras restricciones, por ejemplo, la restricción `ORDER BY` que permite ordenar los resultados de una consulta de manera ascendente (`ASC`) o descendente (`DESC`) a partir de un campo. Por ejemplo, la siguiente consulta muestra los resultados ordenados de mayor a menor a partir del campo `salario`.
 
    ```sql
    SELECT *

--- a/Sesion-01/Reto-03/Readme.md
+++ b/Sesion-01/Reto-03/Readme.md
@@ -23,7 +23,7 @@ Para contestar a esta pregunta, basta con ordenar las calificaciones del alumno 
 
    ```sql
    SELECT *
-   FROM tienda
+   FROM puesto
    ORDER BY salario DESC
    LIMIT 5;
    ```


### PR DESCRIPTION
- Había un typo en una palabra en el ejemplo 4
- La tabla en la respuesta del reto 3 está mal. La consulta usa **tienda** como tabla, y ese es el nombre de la base, el nombre de la tabla debe de ser **puesto**.